### PR TITLE
[Add]customerの郵便番号の表示を改修

### DIFF
--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -14,7 +14,7 @@
             <div class="card-body">
               <dl class="list-customer-data m-0">
                 <dt>郵便番号</dt>
-                <dd><%= address.postal_code %></dd>
+                <dd>〒<%= format_postal_code(address.postal_code) %></dd>
                 <dt>住所</dt>
                 <dd><%= address.address %></dd>
                 <dt>宛名</dt>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -13,7 +13,7 @@
             <dt>カナ</dt>
             <dd><%= @customer.fullname_kana %></dd>
             <dt>郵便番号</dt>
-            <dd><%= @customer.postal_code %></dd>
+            <dd>〒<%= format_postal_code(@customer.postal_code) %></dd>
             <dt>住所</dt>
             <dd><%= @customer.address%></dd>
             <dt>電話番号</dt>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -77,7 +77,7 @@
           お届け先
         </div>
         <div class="card-body">
-          <span>〒<%= @order.postal_code %></span><br>
+          <span>〒<%= format_postal_code(@order.postal_code) %></span><br>
           <span><%= @order.address %></span><br>
           <span><%= @order.name %></span>
         </div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -14,7 +14,7 @@
             <dl class="list-customer-data m-0">
               <dt>配送先</dt>
               <dd>
-                <span>〒<%= order.postal_code %></span><br>
+                <span>〒<%= format_postal_code(order.postal_code) %></span><br>
                 <span><%= order.address %></span><br>
                 <span><%= order.name %>様</span>
               </dd>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -37,7 +37,7 @@
                 <%= form.label :select_address_0, "ご自身の住所", class: "m-0" %>
               </div>
               <div class="form-group ml-4">
-                <span>〒<%= current_customer.postal_code %></span><br>
+                <span>〒<%= format_postal_code(current_customer.postal_code) %></span><br>
                 <span><%= current_customer.address %></span><br>
                 <span><%= current_customer.last_name %><%= current_customer.first_name %></span>
               </div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -12,7 +12,7 @@
             <dd><%= @order.created_at.strftime("%Y/%-m/%-d") %></dd>
             <dt>配送先</dt>
             <dd>
-              <span>〒<%= @order.postal_code %></span><br>
+              <span>〒<%= format_postal_code(@order.postal_code) %></span><br>
               <span><%= @order.address %></span><br>
               <span><%= @order.name %>様</span>
             </dd>


### PR DESCRIPTION
細かいですが、customerの郵便番号にハイフン(-)が表示されるようにしました。
app/helpers/application_helper.rbに
```
def format_postal_code(postal_code)
    postal_code.gsub(/(\d{3})(\d{4})/, '\\1-\\2')
end
```
があるので、そこからとってます。